### PR TITLE
[220629] 주현

### DIFF
--- a/Baekjoon/1244-스위치켜고끄기-JH.py
+++ b/Baekjoon/1244-스위치켜고끄기-JH.py
@@ -1,0 +1,28 @@
+import sys
+ 
+n = int(sys.stdin.readline())
+*switch, = map(int, sys.stdin.readline().split()) 
+ 
+n2 = int(sys.stdin.readline()) 
+ 
+for _ in range(n2):
+    a, b = map(int, sys.stdin.readline().split())   
+    if a == 1 :  
+        plus = b
+        while(b <= n):
+            switch[b-1] = 1-switch[b-1] 
+            b += plus
+    else:  
+        switch[b-1] = 1-switch[b-1]
+        b1 = b-1
+        b2 = b+1 
+        while(b1 >= 1 and b2 <= n): 
+            if (switch[b1-1] == switch[b2-1]):
+                switch[b1-1] = 1-switch[b1-1] 
+                switch[b2-1] = 1-switch[b2-1]  
+            else: break 
+            b1 -= 1
+            b2 += 1  
+
+for i in range(0, n, 20):
+    print(*switch[i:i+20])

--- a/Baekjoon/17413-단어뒤집기2-JH.py
+++ b/Baekjoon/17413-단어뒤집기2-JH.py
@@ -1,0 +1,13 @@
+import sys, re
+
+str = re.split('<|>', sys.stdin.readline().rstrip())   
+
+result = '' 
+
+for i in range(len(str)):
+    if i % 2 == 1:
+        result += '<'+str[i]+'>'
+    else:
+        result += ' '.join(w[::-1] for w in str[i].split())
+
+print(result)


### PR DESCRIPTION
< > 를 기준으로 나눠야겠다고 생각함 -> 나눠서 리스트에 넣을 때 '<'와 '>'를 포함하여 넣을 필요가 있을까? 
-> 포함해서 넣었더니 인덱스로 분류하기 어려워짐 -> '<' ,'>' 빼고 내용만 넣음 -> 분류 기준이 생김
 
* 분류 기준 
입력 받은 문자열 자체에 '<'와'>'가 없다면 처음 분류할때 전체가 인덱스 0에 해당함. 
'<'와'>'가 있다면 홀수번째 인덱스에서만 <>안의 내용이 들어감. 
 
=> 인덱스의 홀수와 짝수로 나눠서 분류 가능해짐  
 
``` 
import sys, re

str = re.split('<|>', sys.stdin.readline().rstrip())   
print(str)

result = '' 

for i in range(len(str)):
    if i % 2 == 1:
        result += '<'+str[i]+'>'
    else:
        result += ' '.join(w[::-1] for w in str[i].split())

print(result) 

```  

 `str = re.split('<|>', sys.stdin.readline().rstrip())` 
 [re.split 관련해서 여러개의 구분자로 나누는 방법](https://velog.io/@highgrace/%EA%B5%AC%EB%B6%84%EC%9E%90-%EC%97%AC%EB%9F%AC%EA%B0%9C%EB%A1%9C-string-to-list)    
 
`result += ' '.join(w[::-1] for w in str[i].split())` 
[join 함수 참고한 사이트](https://blockdmask.tistory.com/468) 


